### PR TITLE
Change ocr image source to look for Dockerfile in root project directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.2"
 services:
   ocr:
-    image: apex_ocr
+    build: .
     network_mode: "host"
     environment:
     - DISPLAY


### PR DESCRIPTION
The purpose of this PR is to streamline the process of building/running a container through Docker Compose. Currently, you either have to 1) build the image manually and call it `apex_ocr` or 2) create a repository called `apex_ocr` (and configure Docker to look for the registry that holds that repo if it is not DockerHub). By specifying the `build` element to point to the current directory of the Docker Compose file, it will automatically use the Dockerfile in that directory to build the image for the `ocr` service.